### PR TITLE
Develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1955,6 +1955,39 @@
         "which": "^2.0.1"
       }
     },
+    "data-view-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+      "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      }
+    },
+    "data-view-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+      "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      }
+    },
+    "data-view-byte-offset": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+      "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      }
+    },
     "debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -2158,6 +2191,15 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true
+    },
+    "es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
     },
     "es-set-tostringtag": {
       "version": "2.0.3",
@@ -3056,6 +3098,15 @@
       "dev": true,
       "requires": {
         "hasown": "^2.0.0"
+      }
+    },
+    "is-data-view": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
+      "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+      "dev": true,
+      "requires": {
+        "is-typed-array": "^1.1.13"
       }
     },
     "is-date-object": {
@@ -4576,13 +4627,13 @@
       }
     },
     "safe-array-concat": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
-      "integrity": "sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+      "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.5",
-        "get-intrinsic": "^1.2.2",
+        "call-bind": "^1.0.7",
+        "get-intrinsic": "^1.2.4",
         "has-symbols": "^1.0.3",
         "isarray": "^2.0.5"
       }
@@ -4605,17 +4656,17 @@
       "dev": true
     },
     "set-function-length": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
-      "integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
       "requires": {
-        "define-data-property": "^1.1.2",
+        "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.3",
+        "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.1"
+        "has-property-descriptors": "^1.0.2"
       }
     },
     "set-function-name": {
@@ -4804,25 +4855,91 @@
       }
     },
     "string.prototype.trim": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
-      "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
+      "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.23.2",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.2.tgz",
+          "integrity": "sha512-60s3Xv2T2p1ICykc7c+DNDPLDMm9t4QxCOUU0K9JxiLjM3C1zB9YVdN7tjxrFd4+AkZ8CdX1ovUga4P2+1e+/w==",
+          "dev": true,
+          "requires": {
+            "array-buffer-byte-length": "^1.0.1",
+            "arraybuffer.prototype.slice": "^1.0.3",
+            "available-typed-arrays": "^1.0.7",
+            "call-bind": "^1.0.7",
+            "data-view-buffer": "^1.0.1",
+            "data-view-byte-length": "^1.0.1",
+            "data-view-byte-offset": "^1.0.0",
+            "es-define-property": "^1.0.0",
+            "es-errors": "^1.3.0",
+            "es-object-atoms": "^1.0.0",
+            "es-set-tostringtag": "^2.0.3",
+            "es-to-primitive": "^1.2.1",
+            "function.prototype.name": "^1.1.6",
+            "get-intrinsic": "^1.2.4",
+            "get-symbol-description": "^1.0.2",
+            "globalthis": "^1.0.3",
+            "gopd": "^1.0.1",
+            "has-property-descriptors": "^1.0.2",
+            "has-proto": "^1.0.3",
+            "has-symbols": "^1.0.3",
+            "hasown": "^2.0.2",
+            "internal-slot": "^1.0.7",
+            "is-array-buffer": "^3.0.4",
+            "is-callable": "^1.2.7",
+            "is-data-view": "^1.0.1",
+            "is-negative-zero": "^2.0.3",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.3",
+            "is-string": "^1.0.7",
+            "is-typed-array": "^1.1.13",
+            "is-weakref": "^1.0.2",
+            "object-inspect": "^1.13.1",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.5",
+            "regexp.prototype.flags": "^1.5.2",
+            "safe-array-concat": "^1.1.2",
+            "safe-regex-test": "^1.0.3",
+            "string.prototype.trim": "^1.2.9",
+            "string.prototype.trimend": "^1.0.8",
+            "string.prototype.trimstart": "^1.0.7",
+            "typed-array-buffer": "^1.0.2",
+            "typed-array-byte-length": "^1.0.1",
+            "typed-array-byte-offset": "^1.0.2",
+            "typed-array-length": "^1.0.5",
+            "unbox-primitive": "^1.0.2",
+            "which-typed-array": "^1.1.15"
+          }
+        },
+        "hasown": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+          "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.2"
+          }
+        }
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
-      "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
+      "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       }
     },
     "string.prototype.trimstart": {
@@ -5163,16 +5280,16 @@
       }
     },
     "which-typed-array": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.14.tgz",
-      "integrity": "sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
       "dev": true,
       "requires": {
-        "available-typed-arrays": "^1.0.6",
-        "call-bind": "^1.0.5",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.1"
+        "has-tostringtag": "^1.0.2"
       }
     },
     "windows-release": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "GPL-3.0",
   "devDependencies": {
     "@mate-academy/eslint-config": "latest",
-    "@mate-academy/scripts": "^1.7.3",
+    "@mate-academy/scripts": "^1.7.8",
     "eslint": "^7.32.0",
     "eslint-plugin-jest": "^22.4.1",
     "eslint-plugin-node": "^8.0.1",

--- a/src/formatDate.js
+++ b/src/formatDate.js
@@ -8,7 +8,77 @@
  * @returns {string}
  */
 function formatDate(date, fromFormat, toFormat) {
-  // write code here
+  const dateParts = date.split(fromFormat[3]);
+  let newDateParts = [];
+
+  toFormat.forEach((part) => {
+    switch (part) {
+      case 'YYYY':
+        newDateParts.push(getFullYear(dateParts, fromFormat));
+        break;
+      case 'YY':
+        newDateParts.push(getShortYear(dateParts, fromFormat));
+        break;
+      case 'MM':
+        newDateParts.push(getMonth(dateParts, fromFormat));
+        break;
+      case 'DD':
+        newDateParts.push(getDay(dateParts, fromFormat));
+        break;
+      default:
+        newDateParts.push(part);
+    }
+  });
+
+  newDateParts = newDateParts.join(toFormat[3]);
+
+  if (newDateParts[newDateParts.length - 2] === toFormat[3]) {
+    newDateParts = newDateParts.slice(0, -2);
+  }
+
+  return newDateParts;
+}
+
+function getFullYear(dateParts, fromFormat) {
+  for (let i = 0; i < fromFormat.length; i++) {
+    if (fromFormat[i] === 'YYYY') {
+      return dateParts[i];
+    } else if (fromFormat[i] === 'YY') {
+      const year = +dateParts[i];
+
+      if (year < 30) {
+        return '20' + dateParts[i];
+      } else {
+        return '19' + dateParts[i];
+      }
+    }
+  }
+}
+
+function getShortYear(dateParts, fromFormat) {
+  for (let i = 0; i < fromFormat.length; i++) {
+    if (fromFormat[i] === 'YY') {
+      return dateParts[i];
+    } else if (fromFormat[i] === 'YYYY') {
+      return dateParts[i].slice(-2);
+    }
+  }
+}
+
+function getMonth(dateParts, fromFormat) {
+  for (let i = 0; i < fromFormat.length; i++) {
+    if (fromFormat[i] === 'MM') {
+      return dateParts[i];
+    }
+  }
+}
+
+function getDay(dateParts, fromFormat) {
+  for (let i = 0; i < fromFormat.length; i++) {
+    if (fromFormat[i] === 'DD') {
+      return dateParts[i];
+    }
+  }
 }
 
 module.exports = formatDate;


### PR DESCRIPTION
Format Date Advanced
Time flies, standards change. Let's get rid of the routine of changing the date format.

Create a formatDate function that accepts the date string, the old fromFormat array and the new toFormat array. Function returns given date in new format.

The function can change a separator, reorder the date parts of convert a year from 4 digits to 2 digits and back.

When converting from YYYY to YY just use 2 last digit (1997 -> 97).
When converting from YY to YYYY use 20YY if YY < 30 and 19YY otherwise.
Examples:

formatDate(
  '2020-02-18',
  ['YYYY', 'MM', 'DD', '-'],
  ['YYYY', 'MM', 'DD', '.'],
); // '2020.02.18'

formatDate(
  '2020-02-18',
  ['YYYY', 'MM', 'DD', '-'],
  ['DD', 'MM', 'YYYY', '.'],
); // '18.02.2020'

formatDate(
  '18-02-2020',
  ['DD', 'MM', 'YYYY', '-'],
  ['DD', 'MM', 'YY', '/'],
); // '18/02/20'

formatDate(
  '20/02/18',
  ['YY', 'MM', 'DD', '/'],
  ['YYYY', 'MM', 'DD', '.'],
); // '2020.02.18'

formatDate(
  '97/02/18',
  ['YY', 'MM', 'DD', '/'],
  ['DD', 'MM', 'YYYY', '.'],
); // '18.02.1997'