### PR TITLE
add task solution

### DIFF
--- a/src/formatDate.js
+++ b/src/formatDate.js
@@ -8,7 +8,36 @@
  * @returns {string}
  */
 function formatDate(date, fromFormat, toFormat) {
-  // write code here
+  const dateArray = date.split(fromFormat[3]);
+  const oldFormatObj = {};
+  const newFormatObj = {};
+  const joinElelement = toFormat[3];
+
+  for (let i = 0; i < dateArray.length; i++) {
+    oldFormatObj[fromFormat[i]] = dateArray[i];
+  }
+
+  for (let i = 0; i < 3; i++) {
+    for (const key in oldFormatObj) {
+      if (key === 'YY' && toFormat[i] === 'YYYY') {
+        if (+oldFormatObj[key] < 30) {
+          newFormatObj[toFormat[i]] = `20${oldFormatObj[key]}`;
+        } else {
+          newFormatObj[toFormat[i]] = `19${oldFormatObj[key]}`;
+        }
+      }
+
+      if (key === 'YYYY' && toFormat[i] === 'YY') {
+        newFormatObj[toFormat[i]] = oldFormatObj[key].slice(-2);
+      }
+
+      if (toFormat[i] === key) {
+        newFormatObj[toFormat[i]] = oldFormatObj[key];
+      }
+    }
+  }
+
+  return Object.values(newFormatObj).join(joinElelement);
 }
 
 module.exports = formatDate;


### PR DESCRIPTION
Create a formatDate function that accepts the date string, the old fromFormat array and the new toFormat array. Function returns given date in new format.

The function can change a separator, reorder the date parts of convert a year from 4 digits to 2 digits and back.

When converting from YYYY to YY just use 2 last digit (1997 -> 97).
When converting from YY to YYYY use 20YY if YY < 30 and 19YY otherwise.