### PR TITLE
Solution

### DIFF
--- a/src/formatDate.js
+++ b/src/formatDate.js
@@ -8,10 +8,15 @@
  * @returns {string}
  */
 function formatDate(date, fromFormat, toFormat) {
-  const [fromSeparator] = fromFormat.splice(-1, 1);
-  const [toSeparator] = toFormat.splice(-1, 1);
-
+  const fromSeparator = fromFormat.slice(-1)[0];
+  const toSeparator = toFormat.slice(-1)[0];
   const dateElements = date.split(fromSeparator);
+
+  const dateMap = fromFormat.reduce((acc, format, index) => {
+    acc[format] = dateElements[index];
+
+    return acc;
+  }, {});
 
   const convertYear = (year, format) => {
     if (format === 'YYYY') {
@@ -25,21 +30,15 @@ function formatDate(date, fromFormat, toFormat) {
     return year;
   };
 
-  const dateMap = fromFormat.reduce((acc, format, index) => {
-    acc[format] = dateElements[index];
+  const formattedDateParts = toFormat.map((format) => {
+    if (format === 'YY' || format === 'YYYY') {
+      return convertYear(dateMap['YYYY'] || dateMap['YY'], format);
+    }
 
-    return acc;
-  }, {});
+    return dateMap[format];
+  });
 
-  return toFormat
-    .map((format) => {
-      if (format === 'YY' || format === 'YYYY') {
-        return convertYear(dateMap['YYYY'] || dateMap['YY'], format);
-      }
-
-      return dateMap[format].padStart(2, '0');
-    })
-    .join(toSeparator);
+  return formattedDateParts.filter(Boolean).join(toSeparator);
 }
 
 module.exports = formatDate;

--- a/src/formatDate.js
+++ b/src/formatDate.js
@@ -8,7 +8,38 @@
  * @returns {string}
  */
 function formatDate(date, fromFormat, toFormat) {
-  // write code here
+  const [fromSeparator] = fromFormat.splice(-1, 1);
+  const [toSeparator] = toFormat.splice(-1, 1);
+
+  const dateElements = date.split(fromSeparator);
+
+  const convertYear = (year, format) => {
+    if (format === 'YYYY') {
+      return year.length === 2 ? (year < 30 ? '20' + year : '19' + year) : year;
+    }
+
+    if (format === 'YY') {
+      return year.slice(-2);
+    }
+
+    return year;
+  };
+
+  const dateMap = fromFormat.reduce((acc, format, index) => {
+    acc[format] = dateElements[index];
+
+    return acc;
+  }, {});
+
+  return toFormat
+    .map((format) => {
+      if (format === 'YY' || format === 'YYYY') {
+        return convertYear(dateMap['YYYY'] || dateMap['YY'], format);
+      }
+
+      return dateMap[format].padStart(2, '0');
+    })
+    .join(toSeparator);
 }
 
 module.exports = formatDate;


### PR DESCRIPTION
## Task description:

Create a `formatDate` function that accepts the `date` string,
the old `fromFormat` array and the new `toFormat` array. Function returns given date in new format.

The function can change a separator, reorder the date parts of convert a year from `4` digits to `2` digits and back.

- When converting from `YYYY` to `YY` just use `2` last digit (`1997` -> `97`).
- When converting from `YY` to `YYYY` use `20YY` if `YY < 30` and `19YY` otherwise.