### PR TITLE
Solution

### DIFF
--- a/src/formatDate.js
+++ b/src/formatDate.js
@@ -8,7 +8,53 @@
  * @returns {string}
  */
 function formatDate(date, fromFormat, toFormat) {
-  // write code here
+  const dateArray = date.split(fromFormat[3]);
+
+  let day, month, year;
+
+  for (let i = 0; i < 3; i++) {
+    if (fromFormat[i].includes('D')) {
+      day = dateArray[i];
+    }
+
+    if (fromFormat[i].includes('M')) {
+      month = dateArray[i];
+    }
+
+    if (fromFormat[i].includes('Y')) {
+      year = dateArray[i];
+
+      if (year.length === 2 && year < 30) {
+        year = 20 + dateArray[i];
+      }
+
+      if (year.length === 2 && year >= 30) {
+        year = 19 + dateArray[i];
+      }
+    }
+  }
+
+  const newDateArray = [];
+
+  for (const part of toFormat) {
+    if (part.includes('DD')) {
+      newDateArray.push(day);
+    }
+
+    if (part.includes('MM')) {
+      newDateArray.push(month);
+    }
+
+    if (part.includes('Y')) {
+      if (part.includes('YYYY')) {
+        newDateArray.push(year);
+      } else {
+        newDateArray.push(year.slice(-2));
+      }
+    }
+  }
+
+  return newDateArray.join(toFormat[3]);
 }
 
 module.exports = formatDate;


### PR DESCRIPTION
Task description:
Create a formatDate function that accepts the date string, the old fromFormat array and the new toFormat array. Function returns given date in new format.

The function can change a separator, reorder the date parts of convert a year from 4 digits to 2 digits and back.

When converting from YYYY to YY just use 2 last digit (1997 -> 97).
When converting from YY to YYYY use 20YY if YY < 30 and 19YY otherwise.
Examples:

formatDate(
  '2020-02-18',
  ['YYYY', 'MM', 'DD', '-'],
  ['YYYY', 'MM', 'DD', '.'],
); // '2020.02.18'

formatDate(
  '2020-02-18',
  ['YYYY', 'MM', 'DD', '-'],
  ['DD', 'MM', 'YYYY', '.'],
); // '18.02.2020'

formatDate(
  '18-02-2020',
  ['DD', 'MM', 'YYYY', '-'],
  ['DD', 'MM', 'YY', '/'],
); // '18/02/20'

formatDate(
  '20/02/18',
  ['YY', 'MM', 'DD', '/'],
  ['YYYY', 'MM', 'DD', '.'],
); // '2020.02.18'

formatDate(
  '97/02/18',
  ['YY', 'MM', 'DD', '/'],
  ['DD', 'MM', 'YYYY', '.'],
); // '18.02.1997'